### PR TITLE
Fix bugs related to animation data properties parser and parent rotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.2.3] - 2021-06-06
+
+- Fix a bug related to data animation properties parser
+- Fix a bug related to parent rotation storing when using JavaScript methods
+
 ## [2.2.2] - 2021-05-28
 
 - Fix a bug with animation positions with negative values

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -5,7 +5,7 @@ export const SCALE = Math.sqrt(3 / 2);
 export const ROT_60 = Math.PI / 3;
 export const ROT_45 = Math.PI / 4;
 export const ROT_CMA = Math.atan(Math.SQRT2);
-export const PROPS_REG_EXP = /(?: |,|^)((?:right|left|top)+)\s*:\s*(-?(?:(?:\d+)?\.\d+|\d+))(?= |,|$)/g;
+export const PROPS_REG_EXP = /(?: |,|^)(right|left|top)\s*:\s*(-?\d*?\.?\d+)(?= |,|$)/g;
 export const EASING_REG_EXP = /^((ease(-in|-out|-in-out)?)|linear|(step(-start|-end)))$/;
 
 export enum VIEW {

--- a/src/utilities/dom.ts
+++ b/src/utilities/dom.ts
@@ -18,7 +18,6 @@ export const getParentRotations = (element: HTMLElement): Rotation[] => {
     while (element.parentElement && element.parentElement !== document.documentElement) {
         const parent = element.parentElement;
         if (
-            parent.classList.contains(NAMESPACE) &&
             !parent.dataset.view &&
             parent.dataset.rotationAxis
         ) {


### PR DESCRIPTION
Animation data properties with values like the next ones were accepted:

```
leftleft: 10, rightright: 5
```

When using `JavaScript` methods, the parent rotations were ignored due to exclusion of elements without the `isometric` class.