### PR TITLE
Remove Demo Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,28 +10,12 @@ updates:
     commit-message:
       prefix: "[Dependencies]"
     groups:
-      dependencies-dev:
-        dependency-type: "development"
-    labels:
-      - dependencies
-    versioning-strategy: increase
-  - package-ecosystem: "npm"
-    directory: "/demo/"
-    schedule:
-      interval: "weekly"
-      day: "sunday"
-      time: "09:00"
-      timezone: "Europe/Amsterdam"
-    commit-message:
-      prefix: "[Demo Dependencies]"
-    groups:
       dependencies-prod:
         dependency-type: "production"
       dependencies-dev:
         dependency-type: "development"
     labels:
       - dependencies
-      - demo
     versioning-strategy: increase
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
This pull request removes the Demo Dependabot configuration because after the project being migrated to `pnpm` workspaces this is not needed anymore because both `package.json` [will be updated in the same Dependabot pull request](https://github.com/elchininet/isometric-css/pull/414).